### PR TITLE
fix: ensure deleted tasks are removed from LocalStorage (Closes #4)

### DIFF
--- a/08-comprehensive-project/app.js
+++ b/08-comprehensive-project/app.js
@@ -117,8 +117,7 @@ class TodoApp {
 
     deleteTodo(id) {
         this.todos = this.todos.filter(t => t.id !== id);
-        // BUG: 忘記呼叫 saveTodos()，導致刪除後重新整理會還原
-        // this.saveTodos();
+        this.saveTodos();
         this.render();
     }
 


### PR DESCRIPTION
## Problem Solved

Closes #4

Fixes the issue where deleted tasks would reappear after refreshing the page because LocalStorage was not updated immediately after deletion.

## 🔧 Implementation Details
- Call `saveTodos()` immediately after deleting a task to ensure LocalStorage is updated
- Keep the `render()` call to update the UI instantly

## Test Steps
1. Start the app and add several tasks
2. Delete a task and confirm it disappears from the UI immediately
3. Refresh the page and confirm the deleted task does not reappear

## 🤔 Special Notes
- Please verify that all delete operations correctly sync with LocalStorage
